### PR TITLE
Fix terminus side detection for zero degrees

### DIFF
--- a/tests/test_moon_phase.py
+++ b/tests/test_moon_phase.py
@@ -1,0 +1,21 @@
+import matplotlib
+matplotlib.use('Agg')
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from MoonPhaseSimulator import terminus_side_finder, simulate_moon_phase
+
+
+def test_terminus_side_zero_returns_side():
+    side = terminus_side_finder(0)
+    assert side in ("left", "right")
+
+
+def test_plotting_angle_zero_runs_without_error():
+    fig, ax = simulate_moon_phase(0)
+    # three lines: two for the circle and one for the terminus
+    assert len(ax.lines) >= 3
+    matplotlib.pyplot.close(fig)


### PR DESCRIPTION
## Summary
- support angle `0` in `terminus_side_finder`
- move plotting code into `simulate_moon_phase` for reuse
- avoid empty ellipse data and handle zero angle gracefully
- add regression tests for angle 0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa304d6f08331a6d29dcebdd67373