### PR TITLE
Fix spacing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # MoonPhaseSimulator
-Simulate the moon-phase(the appearance and the name of the phase) days after the New Moon phase!
+Simulate the moon-phase (the appearance and the name of the phase) days after the New Moon phase!


### PR DESCRIPTION
## Summary
- correct spacing in the README introduction

## Testing
- `python -m py_compile MoonPhaseSimulator.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa3040e348331834eea093d79e043